### PR TITLE
refactor(camp2/builtins): explicitly use output_ptr in return

### DIFF
--- a/camp_2/builtins/cairo/builtins.cairo
+++ b/camp_2/builtins/cairo/builtins.cairo
@@ -21,6 +21,7 @@ func main(output_ptr: felt*) -> (output_ptr: felt*) {
 
     // return the new value of the output_ptr
     // which was advanced by 3
-    [ap] = output_ptr + 3, ap++;
-    ret;
+    let output_ptr = output_ptr + 3;
+
+    return(output_ptr = output_ptr);
 }


### PR DESCRIPTION
This PR proposes to use explicitly `output_ptr` in `camp_2/builtins/cairo/builtins.cairo`. 

Indeed, in previous implementation :

* `output_ptr` is not explicitly return
* the fact that we set `[ap]` to `output_ptr + 3` makes it unclear (at least to me) because at this stage of the basecamp, I do not know why we can use `[ap]` as a vehicle for implicit returned values

 