### PR TITLE
docs(camp_2): add contract example for recursion 

### DIFF
--- a/camp_2/README.md
+++ b/camp_2/README.md
@@ -283,6 +283,16 @@ Segment relocation table:
 
 The table shows the actual (not relative) addresses of the memory cells used by each segment after relocation. Segments 3-4 are empty segments used to return values ​​from `fp` and `pc`. As you can see, the memory ends up being continuous: for example segment 1 starts at cell 29, when segment 0 ends and continues to cell 338, remember we set the value to `[ap+300]` so that the cells 40-337 were automatically filled by the prover. Then segment 2 starts at the next address, 339.
 
+<h3>Recursion instead of loops and an example of implications</h3>
+
+As stated in the Cairo documentation [here](https://www.cairo-lang.org/docs/hello_cairo/intro.html?highlight=loops#recursion-instead-of-loops), we should avoid loops when using Cairo. The main underlying reason is :
+
+> You may have noticed that we’ve used recursion in the code above rather than the loop structure you may have expected. The main reason for this is that the Cairo memory is immutable – once you write the value of a memory cell, this cell cannot change in the future.
+
+Having said that, a developer not coming with a Solidity background might be puzzled by some implications of this property. This is the case when using [storage mappings](https://www.cairo-lang.org/docs/hello_starknet/more_features.html?highlight=mapping). One good example is [this one](https://github.com/starknet-edu/starknet-cairo-101/blob/47c8bd04e762f3c469d6d8d24b169b5145ba9acc/contracts/ex13.cairo#L144) where a storage mapping is filled with some input array provided by the user at contract creation time. In order to validate ex13 of [starknet-cairo-101](https://github.com/starknet-edu/starknet-cairo-101), you will have to find the transaction corresponding to the creation of the contract and reverse-engineer the values in the `values_mapped_secret_storage` storage mapping based on what has been passed to the contract constructor. In order to do so, you will have to have a deep understanding of the type of recursion used. 
+
+Please, nagivate to [recursion/cairo/recursion.cairo](./recursion/cairo/recursion.cairo) and read the code as well with comments to have two examples of recursions. One of which is applicable to how storage mappings deal with it. Instructions on how to compile and run the program are embedded in [recursion/cairo/recursion.cairo](./recursion/cairo/recursion.cairo). 
+
 
 <h3>Types/References</h3>
 

--- a/camp_2/recursion/cairo/recursion.cairo
+++ b/camp_2/recursion/cairo/recursion.cairo
@@ -1,0 +1,117 @@
+// cairo-compile recursion.cairo --output recursion_compiled.json
+// cairo-run --program recursion_compiled.json --print_output --layout=small 
+
+// Run w/ Debug Info:
+// cairo-run --program recursion_compiled.json --print_memory --print_info --trace_file=recursion_trace.bin --memory_file=recursion_memory.bin --relocate_prints
+
+from starkware.cairo.common.alloc import alloc
+
+// init main function
+func main(){
+
+    alloc_locals;
+
+    // Allocate memory and get a pointer to the start of the memory
+    let (array : felt*) = alloc();
+
+    // Filling initial array
+    assert [array] = 10;
+    assert [array + 1] = 11;
+    assert [array + 2] = 12;
+    assert [array + 3] = 13;
+    assert [array + 4] = 14;
+    assert [array + 5] = 15;
+
+    // Copy using recursion and get array in reversed order
+    // Will be usefull when copying arrays into storage mappings
+    // See for instance https://github.com/starknet-edu/starknet-cairo-101/blob/47c8bd04e762f3c469d6d8d24b169b5145ba9acc/contracts/ex05.cairo#L171 
+    // Indeed, for mappings of type
+    // @storage_var
+    // func values_mapped_storage(slot: felt) -> (values_mapped_storage: felt) {
+    // }
+    // One can follow the principles implemented here when populating values coming 
+    // from an array. 
+    // A storage mapping is not a pointer per se (and thus cannot be incremented) and 
+    // it does not have a size per se. 
+    // For the reverse order recursion, all the reasonning is performed on the 
+    // "current" last element of the array : no need of some pointer arythmetics on where
+    // the target array starts  
+    let (arr) = copy_array_reverse_order(6, array);
+    // Checking returned values
+    assert arr[0] = 15;
+    assert arr[1] = 14;
+    assert arr[2] = 13;
+    assert arr[3] = 12;
+    assert arr[4] = 11;
+    assert arr[5] = 10;
+
+    // This is a regular copy like you could see in C or Python. 
+    // Nevetheless, not usefull once you deal with actual contracts (and not 
+    // only just cairo programs)
+    let (arr_2) = copy_array_same_order(6, array);
+    // Checking returned values
+    assert arr_2[0] = 10;
+    assert arr_2[1] = 11;
+    assert arr_2[2] = 12;
+    assert arr_2[3] = 13;
+    assert arr_2[4] = 14;
+    assert arr_2[5] = 15;
+    
+    return ();
+}
+
+///////////////////////////
+// Reverse order functions
+///////////////////////////
+func copy_recursion_reverse_order(values_len: felt, values: felt*, array_res : felt*){
+    if (values_len == 0) {
+        return ();
+    }
+    // In the inner call, we just pass `array_res`
+    copy_recursion_reverse_order(values_len-1, values = values+1, array_res = array_res);
+    assert [array_res + values_len -1] = [values];
+
+    return ();
+}
+
+func copy_array_reverse_order(values_len: felt, values: felt*) -> (array_res : felt*){
+    // `alloc_locals` is required to use Local Variables.
+    // See for instance https://cairo-by-example.org/cairo/variables
+    alloc_locals;
+
+    // Allocate target memory
+    let (array_res : felt*) = alloc();
+
+    copy_recursion_reverse_order(values_len = values_len, values = values, array_res = array_res);
+
+    return (array_res,);
+}
+
+///////////////////////////
+// Same order functions
+///////////////////////////
+
+func copy_recursion_same_order(values_len: felt, values: felt*, array_res : felt*){
+    if (values_len == 0) {
+        return ();
+    }
+    assert [array_res] = [values];
+    // Since we are filling target memory in the same order, one has to 
+    // "update" the start of the rest of the target array. Hence the `array_res = array_res+1`
+    copy_recursion_same_order(values_len-1, values = values+1, array_res = array_res+1);
+
+    return ();
+}
+
+func copy_array_same_order(values_len: felt, values: felt*) -> (array_res : felt*){
+    // `alloc_locals` is required to use Local Variables.
+    // See for instance https://cairo-by-example.org/cairo/variables
+    alloc_locals;
+
+    // Allocate target memory
+    let (array_res : felt*) = alloc();
+
+    copy_recursion_same_order(values_len = values_len, values = values, array_res = array_res);
+
+    return (array_res,);
+}


### PR DESCRIPTION
This PR proposes to add an example about recursion.

It has been placed in `camp_2` because it allows the user to compile and run locally. 

IMO, it is useful to talk about it before jumping into https://github.com/starknet-edu/starknet-cairo-101 and especially [ex13](https://github.com/starknet-edu/starknet-cairo-101/blob/main/contracts/ex13.cairo) which is great and requires to deeply understand how storage mappings are filled using recursions and the impact on the order of information. 

This PR : 

* adds one `camp_2/cairo/recursion.cairo` file to illustrate how recursion might work when dealing with arrays
* modifies `camp_2/README.md` in order to introduce the topic and point to the illustrative contract cited above
 